### PR TITLE
DCR-12 xp.sellerOrderID

### DIFF
--- a/src/app/addPromotion/addPromotion.md
+++ b/src/app/addPromotion/addPromotion.md
@@ -3,5 +3,5 @@
 This component allows buyer users with an open order to apply a Promotion on their order. This component also handles
 the automatically assigned "1% Rebate on Online Orders" Promotion to the cart. The "1% Rebate on Online Orders" assumes:
   1. A ValueExpression of "order.Total * .01" on the Promotion
-  2. A Promotion with the ID of "OnePercentRebate" - This is set in the app constants in gulp.config.js (rebateCode)
+  2. A Promotion with a Code of "OnePercentRebate" - This is set in the app constants in gulp.config.js (rebateCode)
   3. The Promotion has been assigned to ALL Buyers

--- a/src/app/addPromotion/addPromotion.md
+++ b/src/app/addPromotion/addPromotion.md
@@ -3,4 +3,5 @@
 This component allows buyer users with an open order to apply a Promotion on their order. This component also handles
 the automatically assigned "1% Rebate on Online Orders" Promotion to the cart. The "1% Rebate on Online Orders" assumes:
   1. A ValueExpression of "order.Total * .01" on the Promotion
-  2. The Promotion has been assigned to ALL Buyers
+  2. A Promotion with the ID of "OnePercentRebate" - This is set in the app constants in gulp.config.js (rebateCode)
+  3. The Promotion has been assigned to ALL Buyers

--- a/src/app/cart/cart.js
+++ b/src/app/cart/cart.js
@@ -41,11 +41,18 @@ function CartConfig($stateProvider) {
                             return data.Items[0];
                         });
                 },
-                CurrentOrderCart: function(ExistingOrder, NewOrder, AddRebate) {
+                CurrentOrderCart: function(OrderCloud, ExistingOrder, NewOrder, AddRebate, buyerid) {
                     if (!ExistingOrder) {
                         return NewOrder.Create({});
                     } else {
-                        return AddRebate.ApplyPromo(ExistingOrder)
+                        if(ExistingOrder.xp && !ExistingOrder.xp.sellerOrderID) {
+                            return AddRebate.ApplyPromo(ExistingOrder)
+                        } else {
+                            return OrderCloud.Orders.Patch(ExistingOrder.ID, {xp: {sellerOrderID: 0}}, buyerid)
+                                .then(function(order) {
+                                    return AddRebate.ApplyPromo(order);
+                                })
+                        }
                     }
                 },
                 CurrentPromotions: function(CurrentOrderCart, OrderCloud) {


### PR DESCRIPTION
Set xp.sellerOrderID = 0 on all orders for order organization purposes.

Also, updated the ReadMe for AddPromotion to include the app constant for the rebate code so they know where to change that if the promo.Code ever changes.