### PR TITLE
Update Sticky Category Tree Bug

### DIFF
--- a/src/app/productBrowse/templates/productBrowse.tpl.html
+++ b/src/app/productBrowse/templates/productBrowse.tpl.html
@@ -19,7 +19,7 @@
 
         <!--START CATEGORY TREE-->
         <aside class="col-md-3 visible-md visible-lg">
-            <div class="panel panel-default" hl-sticky anchor="top" offset-top="70" stick-limit="true" media-query="min-width: 992px">
+            <div class="panel panel-default">
                 <div class="panel-heading">
                     <b class="panel-title">Categories</b>
                 </div>


### PR DESCRIPTION
Remove extraneous elements from the `category tree` causing some categories to drop out of view when expanded.