### PR TITLE
drop in etundra's mandrill api-key/template slug

### DIFF
--- a/mandrill.config.js
+++ b/mandrill.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    apiKey: process.env.MANDRILL_API_KEY || '_oYXaTujlBWqrTD44W5GTw',
+    apiKey: process.env.MANDRILL_API_KEY || 'b0mdpTDCZMIK8JwV77c00A',
     sendEmails: process.env.MANDRILL_SEND_EMAILS || 'true'
 };

--- a/routes/mandrill.js
+++ b/routes/mandrill.js
@@ -6,7 +6,7 @@ var config = require('../mandrill.config');
 router.route('/negativebalance')
     .post(function(req, res) {
         var data = {
-            TemplateName: 'dfsi_test',
+            TemplateName: 'negative-balance',
             Recipient: req.body.Recipients,
             MergeVars: [
                 {name: 'ORDERNUMBER', content: req.body.Order.ID},

--- a/src/app/orders/orderList/js/orders.config.js
+++ b/src/app/orders/orderList/js/orders.config.js
@@ -18,10 +18,7 @@ function OrdersConfig($stateProvider) {
                     return ocParameters.Get($stateParams);
                 },
                 GroupAssignments: function(OrderCloud) {
-                    return OrderCloud.Me.ListUserGroups()
-                        .then(function(userGroups) {
-                            return userGroups
-                        });
+                    return OrderCloud.Me.ListUserGroups();
                 },
                 OrderList: function(Parameters, CurrentUser, ocOrders, Buyer) {
                     if (Parameters.status === undefined) Parameters.status = '!Unsubmitted';


### PR DESCRIPTION
we had been using our mandrill account and template
for testing purposes. deleting template from our
account so its no longer accessible