### PR TITLE
Fix: Filter by User Group in orders view

### DIFF
--- a/src/app/orders/orderList/js/oc-orders.service.js
+++ b/src/app/orders/orderList/js/oc-orders.service.js
@@ -12,7 +12,7 @@ function ocOrdersService(OrderCloudSDK){
 
         //exclude unsubmitted orders from list
         //parameters.filters = {Status: '!Unsubmitted'};  //TODO: replace this line with below once api can reverse filter enums (EX-1166)
-        parameters.filters = {Status: 'Open|AwaitingApproval|Completed|Canceled|Declined'};
+        // parameters.filters = {Status: 'Open|AwaitingApproval|Completed|Canceled|Declined'};
 
         if(parameters.status){
             angular.extend(parameters.filters, {Status: parameters.status});
@@ -48,11 +48,11 @@ function ocOrdersService(OrderCloudSDK){
 
         if(parameters.tab === 'grouporders') {
             if(parameters.group) {
-                return OrderCloudSDK.Me.ListAddresses({CompanyName: parameters.group})
-                    .then(function(address) {
-                        var shippingAddressID = address.Items[0].ID;
-                        parameters.filters = {ShippingAddressID: shippingAddressID, Status: parameters.status};
-                        return OrderCloudSDK.Me.ListOrders(parameters);
+                return OrderCloudSDK.Me.ListAddresses()
+                    .then(function(addresses) {
+                        var shippingAddress = _.where(addresses.Items, {CompanyName: parameters.group});
+                        parameters.filters = {ShippingAddressID: shippingAddress[0].ID /*, Status: parameters.status*/};
+                        return OrderCloudSDK.Orders.List('Outgoing', parameters);
                     });
             } else {
                 return [];

--- a/src/app/orders/orderList/js/oc-orders.service.js
+++ b/src/app/orders/orderList/js/oc-orders.service.js
@@ -12,7 +12,7 @@ function ocOrdersService(OrderCloudSDK){
 
         //exclude unsubmitted orders from list
         //parameters.filters = {Status: '!Unsubmitted'};  //TODO: replace this line with below once api can reverse filter enums (EX-1166)
-        // parameters.filters = {Status: 'Open|AwaitingApproval|Completed|Canceled|Declined'};
+        parameters.filters = {Status: 'Open|AwaitingApproval|Completed|Cancelled|Declined'};
 
         if(parameters.status){
             angular.extend(parameters.filters, {Status: parameters.status});
@@ -51,7 +51,7 @@ function ocOrdersService(OrderCloudSDK){
                 return OrderCloudSDK.Me.ListAddresses()
                     .then(function(addresses) {
                         var shippingAddress = _.where(addresses.Items, {CompanyName: parameters.group});
-                        parameters.filters = {ShippingAddressID: shippingAddress[0].ID /*, Status: parameters.status*/};
+                        parameters.filters = {ShippingAddressID: shippingAddress[0].ID, Status: parameters.status};
                         return OrderCloudSDK.Orders.List('Outgoing', parameters);
                     });
             } else {


### PR DESCRIPTION
If a buyer user is assigned to more than one user group (meaning that they are a General Manager), they should see a tab to filter orders based on user groups that they are assigned to. 

The orders are being returned based on the addresses assigned to those user groups. When a user selects a user group to filter on, it will return the address assigned to the group, then use the address ID as the order.ShippingAddressID to filter the list of orders.