### PR TITLE
Filter orders by usergroup fix

### DIFF
--- a/src/app/orders/orderList/js/oc-orders.service.js
+++ b/src/app/orders/orderList/js/oc-orders.service.js
@@ -48,10 +48,16 @@ function ocOrdersService(OrderCloudSDK){
 
         if(parameters.tab === 'grouporders') {
             if(parameters.group) {
-                return OrderCloudSDK.Me.ListAddresses()
+                var options = {
+                    filters: {
+                        CompanyName: parameters.group
+                    }
+
+                }
+                return OrderCloudSDK.Me.ListAddresses(options)
                     .then(function(addresses) {
-                        var shippingAddress = _.where(addresses.Items, {CompanyName: parameters.group});
-                        angular.extend(parameters.filters, {ShippingAddressID: shippingAddress[0].ID});
+                        var shippingAddress = addresses.Items[0];
+                        angular.extend(parameters.filters, {ShippingAddressID: shippingAddress.ID});
                         return OrderCloudSDK.Orders.List('Outgoing', parameters);
                     });
             } else {

--- a/src/app/orders/orderList/js/orders.config.js
+++ b/src/app/orders/orderList/js/orders.config.js
@@ -21,18 +21,11 @@ function OrdersConfig($stateProvider) {
                     return ocOrders.List(Parameters, CurrentUser, Buyer);
 
                 },
-                GroupAssignments: function(OrderCloudSDK) {
-                    return OrderCloudSDK.Me.ListAddresses()
-                        .then(function(addresses) {
-                            return OrderCloudSDK.Me.ListUserGroups()
-                                .then(function(userGroups) {
-                                    var userGroupsArr = [];
-                                    _.each(addresses.Items, function(address) {
-                                        userGroupsArr.push(_.findWhere(userGroups.Items, {ID: address.CompanyName}));
-                                    });
-                                    return _.compact(userGroupsArr);
-                                });
-                        });
+                GroupAssignments: function(OrderCloudSDK, ocUtility) {
+                    return ocUtility.ListAll(OrderCloudSDK.Me.ListUserGroups, {pageSize: 100, page: 'page'})
+                        .then(function(userGroups) {
+                            return userGroups.Items;
+                    });
                 },
                 CanSeeAllOrders: function(OrderCloudSDK){
                     return OrderCloudSDK.Me.ListUserGroups({search: 'CanViewAllOrders', searchOn: 'ID', pageSize: 1})


### PR DESCRIPTION
Users that are assigned to more than 100 user groups were not seeing all of them in the drop down to filter on. 